### PR TITLE
Connect upon hitting Enter from the password field

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,13 @@
 
 			// Build the default wsProxy URL for display on sidenav
 			buildWSProxyURL()
+
+			// Connect upon hitting Enter from the password field
+			document.getElementById("password").addEventListener("keyup", function(event) {
+				if(event.key !== "Enter") return;
+				document.getElementById("connect").click();
+				event.preventDefault();
+			});
 		};
 
 		// Run every time the webpage is resized


### PR DESCRIPTION
Alter the login form behavior, so that hitting Enter after typing the
password is equivalent to clicking the Connect button.